### PR TITLE
refactor(promote): delegar lógica bloqueante de `promote_to_dev` a `promote_dev_monitor`

### DIFF
--- a/lib/promote/workflows/to-dev.sh
+++ b/lib/promote/workflows/to-dev.sh
@@ -145,54 +145,6 @@ promote_to_dev() {
     echo "⏳ Habilitando auto-merge (espera aprobación + checks)..."
     GH_PAGER=cat gh pr merge "$pr_number" --auto --squash --delete-branch
 
-    echo "🔄 Esperando merge del PR #$pr_number..."
-    local merge_sha
-    merge_sha="$(wait_for_pr_merge_and_get_sha "$pr_number")"
-
-    sync_branch_to_origin "dev" "origin"
-
-    # Esperar PR del bot (release-please) si existe el workflow.
-    # Importante: release-please puede decidir NO abrir PR si no hay bump; en ese caso seguimos.
-    if repo_has_workflow_file "release-please"; then
-        echo
-        log_info "🤖 Esperando PR del bot release-please hacia dev..."
-        local rp_pr
-        rp_pr="$(wait_for_release_please_pr_number_or_die 2>/dev/null || true)"
-
-        if [[ -n "${rp_pr:-}" ]]; then
-            log_info "🤖 Habilitando auto-merge para PR del bot (#$rp_pr)..."
-            # Importante: NO borramos la rama aquí; se limpia en promote staging.
-            GH_PAGER=cat gh pr merge "$rp_pr" --auto --squash
-
-            echo "🔄 Esperando merge del PR del bot #$rp_pr..."
-            local rp_merge_sha
-            rp_merge_sha="$(wait_for_pr_merge_and_get_sha "$rp_pr")"
-
-            sync_branch_to_origin "dev" "origin"
-        else
-            log_warn "🤷 No se detectó PR release-please--* en la ventana de espera. Continuando."
-        fi
-    fi
-
-    # En este punto, el SHA “válido” es el HEAD de dev (post-bot si existió)
-    local dev_sha
-    dev_sha="$(git rev-parse HEAD 2>/dev/null || true)"
-
-    # Esperar build-push en dev si existe en este repo (PMBOK sí, erd-ecosystem no)
-    if repo_has_workflow_file "build-push"; then
-        wait_for_workflow_success_on_ref_or_sha_or_die "build-push.yaml" "$dev_sha" "dev" "Build and Push"
-    fi
-
-    write_golden_sha "$dev_sha" "source=origin/dev post_release_please=1" || true
-    log_success "✅ GOLDEN_SHA (post-bot) capturado: $dev_sha"
-
-    local changed_paths
-    changed_paths="$(git diff --name-only HEAD~1..HEAD 2>/dev/null || true)"
-    maybe_trigger_gitops_update "dev" "$dev_sha" "$changed_paths"
-
-    banner "✅ DEV LISTO (post-bot + build OK)"
-    echo "👉 Siguiente paso: git promote staging"
-    exit 0
     # Default: async (libera terminal).
     # Compat: DEVTOOLS_PROMOTE_DEV_SYNC=1 vuelve al modo bloqueante.
     local sync="${DEVTOOLS_PROMOTE_DEV_SYNC:-0}"


### PR DESCRIPTION
Se elimina el flujo sync inline (espera de merge, `release-please`, `build-push` y escritura de `GOLDEN_SHA`) para centralizarlo en `promote_dev_monitor` y mantener `promote_to_dev` enfocado en el modo async.

📅 Fecha: 2026-01-27 23:44

Conteo: commit #38
