### PR TITLE
feat(devtools): local up con perfiles basic/full

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ Ruta: `apps/pmbok/frontend`
 2. Para PMBOK: entra a `apps/pmbok` y ejecuta `task ci`.
 3. Para El Rincon: entra a `apps/el-rincon-del-detective` y ejecuta `task ci`.
 4. Para desarrollo: entra al servidor o cliente y ejecuta `task run`.
+
+**Comando local up (erd-ecosystem)**
+- `devtools local up --profile basic` aplica `devops/k8s/bootstrap-local-basic.yaml` (sin observabilidad).
+- `devtools local up --profile full` aplica `devops/k8s/bootstrap-local.yaml` (con observabilidad).
+- Si no indicas `--profile`, usa `basic`.
+- Con `DEVTOOLS_DRY_RUN=1` no ejecuta `kubectl apply`; solo imprime la accion.
+- Si el repo no contiene esos bootstraps, falla con mensaje claro (pendiente soporte para app-repos).

--- a/devtools
+++ b/devtools
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Uso:
+  devtools local up [--profile basic|full]
+
+Opciones:
+  --profile   Perfil de bootstrap local (default: basic)
+  -h, --help  Muestra esta ayuda
+
+Notas:
+  - basic -> devops/k8s/bootstrap-local-basic.yaml
+  - full  -> devops/k8s/bootstrap-local.yaml
+  - DEVTOOLS_DRY_RUN=1 solo muestra acciones (sin kubectl apply)
+EOF
+}
+
+log_info() { echo "ℹ️  $*"; }
+log_ok() { echo "✅ $*"; }
+log_warn() { echo "⚠️  $*"; }
+log_error() { echo "❌ $*" >&2; }
+
+die() {
+  log_error "$*"
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Comando requerido no encontrado: $1"
+}
+
+resolve_repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+resolve_profile_bootstrap_or_die() {
+  local repo_root="$1"
+  local profile="$2"
+
+  case "$profile" in
+    basic)
+      echo "${repo_root}/devops/k8s/bootstrap-local-basic.yaml"
+      ;;
+    full)
+      echo "${repo_root}/devops/k8s/bootstrap-local.yaml"
+      ;;
+    *)
+      die "Perfil inválido: '${profile}'. Usa --profile basic|full."
+      ;;
+  esac
+}
+
+local_up() {
+  local profile="basic"
+
+  while (( $# )); do
+    case "$1" in
+      --profile)
+        profile="${2:-}"
+        [[ -n "$profile" ]] || die "Falta valor para --profile"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *)
+        die "Opción desconocida para 'local up': $1"
+        ;;
+    esac
+  done
+
+  local repo_root
+  repo_root="$(resolve_repo_root)"
+
+  local bootstrap
+  bootstrap="$(resolve_profile_bootstrap_or_die "$repo_root" "$profile")"
+
+  if [[ ! -f "$bootstrap" ]]; then
+    die "Este repo no tiene bootstrap local (${bootstrap}). Pendiente soportar app-repos."
+  fi
+
+  log_info "Perfil seleccionado: ${profile}"
+  log_info "Bootstrap: ${bootstrap}"
+
+  if [[ "${DEVTOOLS_DRY_RUN:-0}" == "1" ]]; then
+    log_warn "DEVTOOLS_DRY_RUN=1: omito 'kubectl apply -f ${bootstrap}'."
+    return 0
+  fi
+
+  require_cmd kubectl
+  kubectl apply -f "$bootstrap"
+  log_ok "Bootstrap aplicado: ${bootstrap}"
+}
+
+main() {
+  local cmd="${1:-}"
+  local subcmd="${2:-}"
+
+  case "$cmd" in
+    local)
+      if [[ "$subcmd" != "up" ]]; then
+        die "Uso inválido. Prueba: devtools local up --profile basic|full"
+      fi
+      shift 2
+      local_up "$@"
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      die "Comando no soportado: ${cmd}. Prueba: devtools local up --profile basic|full"
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/local-up.sh
+++ b/tests/local-up.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVTOOLS_BIN="${ROOT_DIR}/devtools"
+
+pass=0
+fail=0
+
+ok() {
+  echo "✅ $1"
+  pass=$((pass + 1))
+}
+
+ko() {
+  echo "❌ $1" >&2
+  fail=$((fail + 1))
+}
+
+mk_git_repo() {
+  local dir="$1"
+  git -C "$dir" init -q
+  git -C "$dir" config user.name "Test Bot"
+  git -C "$dir" config user.email "test@example.com"
+}
+
+test_profile_basic_and_full() {
+  local tdir
+  tdir="$(mktemp -d)"
+  trap 'rm -rf "$tdir"' RETURN
+
+  mkdir -p "$tdir/devops/k8s" "$tdir/bin"
+  mk_git_repo "$tdir"
+  : > "$tdir/devops/k8s/bootstrap-local-basic.yaml"
+  : > "$tdir/devops/k8s/bootstrap-local.yaml"
+
+  cat > "$tdir/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${MOCK_KUBECTL_LOG:?}"
+EOF
+  chmod +x "$tdir/bin/kubectl"
+
+  export MOCK_KUBECTL_LOG="$tdir/kubectl.log"
+  : > "$MOCK_KUBECTL_LOG"
+
+  (
+    cd "$tdir"
+    PATH="$tdir/bin:$PATH" "$DEVTOOLS_BIN" local up --profile basic >"$tdir/out-basic.log"
+    PATH="$tdir/bin:$PATH" "$DEVTOOLS_BIN" local up --profile full >"$tdir/out-full.log"
+  )
+
+  if rg -n "bootstrap-local-basic\.yaml" "$tdir/out-basic.log" >/dev/null \
+    && rg -n "bootstrap-local\.yaml" "$tdir/out-full.log" >/dev/null \
+    && rg -n "apply -f .*bootstrap-local-basic\.yaml" "$MOCK_KUBECTL_LOG" >/dev/null \
+    && rg -n "apply -f .*bootstrap-local\.yaml" "$MOCK_KUBECTL_LOG" >/dev/null; then
+    ok "--profile basic/full resuelve bootstrap correcto"
+  else
+    ko "--profile basic/full no resolvió bootstrap como se esperaba"
+  fi
+}
+
+test_dry_run_no_kubectl() {
+  local tdir
+  tdir="$(mktemp -d)"
+  trap 'rm -rf "$tdir"' RETURN
+
+  mkdir -p "$tdir/devops/k8s" "$tdir/bin"
+  mk_git_repo "$tdir"
+  : > "$tdir/devops/k8s/bootstrap-local-basic.yaml"
+
+  cat > "$tdir/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "KUBECTL_NO_DEBERIA_EJECUTARSE" >&2
+exit 99
+EOF
+  chmod +x "$tdir/bin/kubectl"
+
+  (
+    cd "$tdir"
+    DEVTOOLS_DRY_RUN=1 PATH="$tdir/bin:$PATH" "$DEVTOOLS_BIN" local up --profile basic >"$tdir/out-dry.log"
+  )
+
+  if rg -n "DEVTOOLS_DRY_RUN=1" "$tdir/out-dry.log" >/dev/null \
+    && rg -n "bootstrap-local-basic\.yaml" "$tdir/out-dry.log" >/dev/null; then
+    ok "DEVTOOLS_DRY_RUN=1 evita kubectl apply"
+  else
+    ko "DEVTOOLS_DRY_RUN=1 no reportó comportamiento esperado"
+  fi
+}
+
+test_missing_bootstrap_fails() {
+  local tdir
+  tdir="$(mktemp -d)"
+  trap 'rm -rf "$tdir"' RETURN
+
+  mkdir -p "$tdir" "$tdir/bin"
+  mk_git_repo "$tdir"
+
+  set +e
+  (
+    cd "$tdir"
+    PATH="$tdir/bin:$PATH" "$DEVTOOLS_BIN" local up --profile basic >"$tdir/out-missing.log" 2>&1
+  )
+  local rc=$?
+  set -e
+
+  if [[ "$rc" -ne 0 ]] && rg -n "Pendiente soportar app-repos" "$tdir/out-missing.log" >/dev/null; then
+    ok "falla con error claro cuando no existe bootstrap"
+  else
+    ko "no falló como se esperaba en repo sin bootstrap"
+  fi
+}
+
+test_profile_basic_and_full
+test_dry_run_no_kubectl
+test_missing_bootstrap_fails
+
+echo "---"
+echo "RESULTADO: pass=${pass} fail=${fail}"
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Resumen
- agrega comando `devtools local up`
- soporta `--profile basic|full` (default: `basic`)
- en `DEVTOOLS_DRY_RUN=1` no ejecuta `kubectl apply`
- si el repo no tiene bootstrap local, falla con error claro

## Pruebas
- `bash -n devtools`
- `bash -n tests/local-up.sh`
- `./tests/local-up.sh`

## Notas
- scope de Iteración 2: soporte para `erd-ecosystem`
- pendiente futuro: soporte app-repos
